### PR TITLE
Fix for TOC-relative path conversion

### DIFF
--- a/src/Docs/MethodLink.cs
+++ b/src/Docs/MethodLink.cs
@@ -36,7 +36,6 @@ public class MethodLink(string title, string filePath, string? heading = null)
     public bool IsValid(string resourceDocumentFilePath)
     {
         // Is this a file path?
-
         var filePath = FilePath.NormalizeFilePath().TrimAnchor();
         var fileExtension = Path.GetExtension(filePath);
         if (string.IsNullOrEmpty(fileExtension))

--- a/src/Extensions/StringExtensions.cs
+++ b/src/Extensions/StringExtensions.cs
@@ -111,7 +111,8 @@ public static partial class StringExtensions
             // If there is no file extension, this is a relative URL,
             // not a file path. Return the value unchanged.
             var fileExtension = Path.GetExtension(value);
-            if (string.IsNullOrEmpty(fileExtension))
+            if (string.IsNullOrEmpty(fileExtension) ||
+                (!fileExtension.TrimAnchor().IsEqualIgnoringCase(".md") && !fileExtension.TrimAnchor().IsEqualIgnoringCase(".yml")))
             {
                 return value;
             }

--- a/test/StringExtensionsTests.cs
+++ b/test/StringExtensionsTests.cs
@@ -143,14 +143,34 @@ public class StringExtensionsTests
             .Replace('/', Path.DirectorySeparatorChar);
         var relativePath = "../api/event-get.md"
             .Replace('/', Path.DirectorySeparatorChar);
+        var relativePathWithAnchor = "../api/user-post-messages.md#request-2"
+            .Replace('/', Path.DirectorySeparatorChar);
 
         // Act
         var convertedFullPath = fullPath.ToTocRelativePath();
         var convertedRelativePath = relativePath.ToTocRelativePath();
+        var convertedRelativePathWithAnchor = relativePathWithAnchor.ToTocRelativePath();
 
         // Assert
         Assert.Equal("../../resources/event.md", convertedFullPath);
         Assert.Equal("../../api/event-get.md", convertedRelativePath);
+        Assert.Equal("../../api/user-post-messages.md#request-2", convertedRelativePathWithAnchor);
+    }
+
+    [Fact]
+    public void RelativeUrlPathsDoNotConvert()
+    {
+        // Arrange
+        var betaRelativeUrl = "/graph/extensibility-overview?context=graph%2Fapi%2Fbeta&preserve-view=true";
+        var v1RelativeUrl = "/graph/extensibility-overview?context=graph%2Fapi%2F1.0&preserve-view=true";
+
+        // Act
+        var convertedBetaPath = betaRelativeUrl.ToTocRelativePath();
+        var convertedV1Path = v1RelativeUrl.ToTocRelativePath();
+
+        // Assert
+        Assert.Equal(betaRelativeUrl, convertedBetaPath);
+        Assert.Equal(v1RelativeUrl, convertedV1Path);
     }
 
     public static TheoryData<string, string> CamelCaseData => new()


### PR DESCRIPTION
Relative URLs were incorrectly being identified as a file path due to a `.` in the path.