### PR TITLE
Updated TOC node name to prefer name from doc

### DIFF
--- a/src/GenerateTOC.csproj
+++ b/src/GenerateTOC.csproj
@@ -20,7 +20,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
-    <PackageReference Include="YamlDotNet" Version="15.3.0" />
+    <PackageReference Include="YamlDotNet" Version="16.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Generation/TableOfContentsGenerator.cs
+++ b/src/Generation/TableOfContentsGenerator.cs
@@ -298,7 +298,9 @@ public class TableOfContentsGenerator(GeneratorOptions options, ILogger logger)
 
             _ = resourceDoc ?? throw new Exception("No matches found");
 
-            var resourceTocNodeName = resourceDoc.TocTitleOverride ?? resource.Name.SplitCamelCaseToSentenceCase();
+            var resourceTocNodeName = resourceDoc.TocTitleOverride ??
+                resourceDoc.ResourceName?.SplitCamelCaseToSentenceCase() ??
+                resource.Name.SplitCamelCaseToSentenceCase();
             var overview = resourceOverviews?.SingleOrDefault(o => o.Resource != null && o.Resource.IsEqualIgnoringCase(resource.Name));
 
             // If the resource has no methods and no overview,

--- a/tools/split-toc/SplitTOC.csproj
+++ b/tools/split-toc/SplitTOC.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
-    <PackageReference Include="YamlDotNet" Version="15.3.0" />
+    <PackageReference Include="YamlDotNet" Version="16.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Previously it was using the name from the mapping file, and when the case didn't match, it was generating odd results.